### PR TITLE
Build with --server-only flag

### DIFF
--- a/cmd/meteor-dockerfilegen/main.go
+++ b/cmd/meteor-dockerfilegen/main.go
@@ -80,7 +80,7 @@ RUN curl -o $TMP_DIR/meteor.sh 'https://install.meteor.com?release={{.MeteorVers
 ENV PATH="/home/node/.meteor:${PATH}"
 WORKDIR $SRC_DIR
 RUN meteor npm install --production
-RUN meteor build --directory $BUNDLE_DIR
+RUN meteor build --server-only --directory $BUNDLE_DIR
 RUN cd ${BUNDLE_DIR}/bundle/programs/server && npm install
 
 FROM node:{{.NodeVersion}}{{if .SlimBase}}-slim{{end}}


### PR DESCRIPTION
Since a mobile app build would not be useful for the deployed server, we
can safely add the `--server-only` flag.  Thanks to @jaskinn for
pointing this out.

Fixes issue #1